### PR TITLE
MIME JPEG fix. Tested with RN 0.61.5, 0.64.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ react-native link react-native-webview
 react-native link react-native-image-picker
 ```
 
+Note: Xcode 12.5 requires at least React Native 0.64.1. 
+
 4. Optional: When using the image upload functionality
 
 The SDK allows users to pick an image from her/his device to upload as a screenshot. 

--- a/api/feedback.js
+++ b/api/feedback.js
@@ -37,7 +37,7 @@ export const feedback = {
 		});
 	},
 	postFeedback(feedback) {
-		const url = 'https://survey.collect.mopinion.com/api/1/data';
+		const url = 'https://survey.mopinion.com/api/1/data';
 		let data = {
 			method: 'POST',
 			body: JSON.stringify(feedback),

--- a/components/ScreenshotBlock.js
+++ b/components/ScreenshotBlock.js
@@ -62,8 +62,11 @@ class ImagePickerControl extends React.Component {
 	validatePickedImage(response) {
 		if(response && response.uri !== "" ) {
 			switch(response.type) {
-				case 'image/png':
 				case 'image/jpg':
+					response.type = 'image/jpeg';	// convert to MIME standard
+					break;
+				case 'image/jpeg':
+				case 'image/png':
 					break;
 				default:
 					Alert.alert('Unsupported Image', `Format '${response.type}' is not supported. Please select a JPG or PNG image.`);


### PR DESCRIPTION
Converted Image Picker response from "image/jpg" to MIME standard "image/jpeg", this also fixes the JPEG support on Android.